### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,12 @@ The agent comes equipped with several tools to interact with web pages:
     uvicorn app.main:app --reload --port 8000 
     ```
 
+   For Windows User:
+
+    ```bash
+    uvicorn app.main:app --port 8000
+    ```
+
 6. Access the API at `http://localhost:8000`
 
 ## Frontend Setup


### PR DESCRIPTION
This PR updates the README to include specific guidance for Windows users running the backend server. It addresses the known compatibility issue between FastAPI's --reload flag and Playwright on Windows, which results in a NotImplementedError.