### PR TITLE
Resolving playwright issue

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@playwright/test": "^1.48.0",
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",
     "framer-motion": "^12.0.1",

--- a/readme.md
+++ b/readme.md
@@ -184,8 +184,8 @@ The agent comes equipped with several tools to interact with web pages:
 2. Install dependencies:
     ```bash
     npm install
+    playwright install
     ```
-
 3. Run the frontend:
     ```bash
     npm run dev


### PR DESCRIPTION
Issue replicated:

On Mac after running ```npm run dev``` , once browser is launched and “Connect to browser” is clicked, user faces below error

`“Failed to setup browser: BrowserType.launch: Executable doesn't exist at /Users/<yourUserName>/Library/Caches/ms-playwright/chromium-1148/chrome-mac/Chromium.app/Contents/MacOS/Chromium”`

<img width="572" alt="playwright_error" src="https://github.com/user-attachments/assets/60dbb8a3-9de1-4c01-8583-63f109537bff" />


Added :

- the playwright dependency in package.json that loads the specific `chroium-1148` 
- instructions of `playwright install` in readme 
