### PR TITLE
Feature/fix element xpath bug

### DIFF
--- a/backend/app/task_agent.py
+++ b/backend/app/task_agent.py
@@ -577,7 +577,7 @@ async def decide_immediate_action(state: AgentState):
         5. Get all link elements: This will be the action you take if you decide you need to open a link
         6. Go Back: If you decide you need to go back to the previous page, you should respond with "Go Back"
         7. Go To Search: If you decide you need to go to a search engine, you should respond with "Go To Search"
-            - Dont call Go To Search if you are already on google.com as indicated by the current page url or if you have already navigated to google.com in the previous step.
+            - Avoid to call Go To Search if you are already on google.com as indicated by the current page url or if you have already navigated to google.com in the previous step.
         8. Wait: If you decide you need to wait for a page to load, you should respond with "Wait"
         9. Type in a text editor: If you decide you need to type in a text editor such as a google doc or some similar text editor based on the user input, you should respond with "Type in a text editor"
             - If you end up at a point where you need to type in a text editor after navigating to the respective text editor url, skip the other steps and directly respond with "Type in a text editor" since, this step has the ability to infer dom element for text editor
@@ -956,7 +956,7 @@ async def click(state: AgentState):
                     bbox_x, bbox_y
                 )
                 await asyncio.sleep(0.5)
-            except Exception:
+            except Exception as e:
                 return {"actions_taken": [f"Failed to scroll to element: {str(e)}"]}
 
     

--- a/backend/marking_scripts/marking_buttons_2.js
+++ b/backend/marking_scripts/marking_buttons_2.js
@@ -60,7 +60,7 @@ function captureInteractiveElements(options = {}) {
         .filter(e => e.tagName === current.tagName)
         .indexOf(current) + 1;
       parts.unshift(
-        index > 1
+        index > 0
           ? `${current.tagName.toLowerCase()}[${index}]`
           : current.tagName.toLowerCase()
       );

--- a/backend/marking_scripts/marking_input.js
+++ b/backend/marking_scripts/marking_input.js
@@ -60,7 +60,7 @@ function captureInteractiveElements(options = {}) {
         .filter(e => e.tagName === current.tagName)
         .indexOf(current) + 1;
       parts.unshift(
-        index > 1
+        index > 0
           ? `${current.tagName.toLowerCase()}[${index}]`
           : current.tagName.toLowerCase()
       );

--- a/backend/marking_scripts/marking_links.js
+++ b/backend/marking_scripts/marking_links.js
@@ -60,7 +60,7 @@ function captureInteractiveElements(options = {}) {
         .filter(e => e.tagName === current.tagName)
         .indexOf(current) + 1;
       parts.unshift(
-        index > 1
+        index > 0
           ? `${current.tagName.toLowerCase()}[${index}]`
           : current.tagName.toLowerCase()
       );


### PR DESCRIPTION
Use case: Task agent.

Issue: During the execution of Click(), when reaching the following code:
await page.locator(f'xpath={xpath}').click(
    modifiers=["Control"],
    timeout=5000,
    force=attempts == max_attempts
)

An exception occurs because the given XPath refers to multiple elements, but it should only refer to the first element [1].

Fix: Added the string [index] to the XPath also for the first element when retrieving elements via JavaScript.

---

Additional changes: Refactored the prompt to replace negative expressions such as "don't" with positive alternatives like "avoid".